### PR TITLE
Avoid encoding

### DIFF
--- a/Url.cpp
+++ b/Url.cpp
@@ -7,8 +7,8 @@
 #include "utils.hpp"
 
 Url::Url(const std::string &url, bool regex_mode)
+    : url_string(url)
 {
-    url_string = url;
     if (regex_mode)
     {
         this->regex_parse();
@@ -69,10 +69,6 @@ void Url::set_fragment(const std::string &fragment)
 
 const std::string &Url::get_url_string() const {
     return url_string;
-}
-
-void Url::set_url_string(const std::string &url_string) {
-    Url::url_string = url_string;
 }
 
 bool Url::is_encoded(const std::string &u) {

--- a/Url.hpp
+++ b/Url.hpp
@@ -13,7 +13,7 @@ const std::regex URL_REGEX (R"(^(([^:\/?#]+):)?(//([^\/?#]*))?([^?#]*)(\?([^#]*)
 
 class Url {
 private:
-    std::string url_string;
+    const std::string url_string;
     std::string scheme;
     std::string hostname;
     std::string path;
@@ -49,8 +49,6 @@ public:
     bool parse();
 
     std::string get_url_key();
-
-    void set_url_string(const std::string &url_string);
 };
 
 #endif //URLDEDUPE_URL_HPP

--- a/main.cpp
+++ b/main.cpp
@@ -58,14 +58,6 @@ int main(int argc, char **argv) {
     {
         Url parsed_url(u, regex_mode);
 
-        // Decode URLs before assessing
-        bool was_encoded {false};
-        if (Url::is_encoded(parsed_url.get_url_string()))
-        {
-            parsed_url.set_url_string(parsed_url.decode());
-            was_encoded = true;
-        }
-
         std::string url_key {parsed_url.get_url_key()};
         if (deduped_url_keys.find(url_key) != deduped_url_keys.end())
         {
@@ -73,12 +65,6 @@ int main(int argc, char **argv) {
         }
 
         deduped_url_keys.insert(std::make_pair(url_key, true));
-
-        // Re-encode back to original value after dupe check
-        if (was_encoded)
-        {
-            parsed_url.set_url_string(parsed_url.encode());
-        }
 
         // If it has made it to this point, it's a non-duplicate URL. Print it
         std::cout << parsed_url.get_url_string() << std::endl;


### PR DESCRIPTION
To avoid having to decode and then re-encode _all_ of the URLs, store their original name in `Url`
The decoding is done in `parse` anyway, which is called from the constructor