### PR TITLE
Bug fix when using -r option

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -41,7 +41,8 @@ int main(int argc, char **argv) {
             load_urls_from_file(urls, option.value);
         }
 
-        regex_mode = option.flag.short_name == "-r";
+        if(option.flag.short_name == "-r")
+            regex_mode = true;
     }
 
     if (!url_file_provided)


### PR DESCRIPTION
If the program is called with the `-r` option, and another option is supplied after it, `regex_mode` will be set back to `false`. This fixes that.