### PR TITLE
File parse

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
         regex_mode = option.flag.short_name == "-r";
     }
 
-    if (filename.length() == 0) {
+    if (filename.length() > 0) {
         load_urls_from_file(urls, filename, regex_mode);
     }
     else {

--- a/main.cpp
+++ b/main.cpp
@@ -17,10 +17,10 @@ int main(int argc, char **argv) {
         options = parse_flags(argc, argv);
     }
 
-    std::vector<std::string> urls {};
-    std::string url {};
+    std::vector<Url> urls {};
+    std::string filename {};
 
-    bool url_file_provided, regex_mode {false};
+    bool regex_mode {false};
     for (const Option &option: options)
     {
         if (option.flag.short_name == "-h")
@@ -37,27 +37,23 @@ int main(int argc, char **argv) {
 
         if (option.flag.short_name == "-u")
         {
-            url_file_provided = true;
-            load_urls_from_file(urls, option.value);
+            filename = option.value;
         }
 
         regex_mode = option.flag.short_name == "-r";
     }
 
-    if (!url_file_provided)
-    {
-        while (getline(std::cin, url))
-        {
-            urls.push_back(url);
-        }
+    if (filename.length() == 0) {
+        load_urls_from_file(urls, filename, regex_mode);
+    }
+    else {
+        read_urls_from_stream(urls, std::cin, regex_mode);
     }
 
     std::unordered_map<std::string, bool> deduped_url_keys;
     std::vector<Url> deduped_urls {};
-    for (const std::string &u: urls)
+    for (auto &parsed_url: urls)
     {
-        Url parsed_url(u, regex_mode);
-
         std::string url_key {parsed_url.get_url_key()};
         if (deduped_url_keys.find(url_key) != deduped_url_keys.end())
         {

--- a/utils.cpp
+++ b/utils.cpp
@@ -8,23 +8,26 @@
 #include <fstream>
 #include "utils.hpp"
 
-bool load_urls_from_file(std::vector<std::string> &urls, const std::string &filename)
+#include "Url.hpp"
+
+
+bool load_urls_from_file(std::vector<Url> &urls, const std::string &filename, bool regex_mode) 
 {
     std::ifstream file (filename);
-    if (!file.is_open()) {
+    if (!file) {
         std::cout << "Unable to open file " << filename << std::endl;
         return false;
     }
-
-    std::string url;
-    while (file.good()) {
-        getline(file, url);
-        if (!url.empty())
-        {
-            urls.push_back(url);
-        }
+    else {
+        read_urls_from_stream(urls, file, regex_mode);
+        return true;
     }
-    file.close();
+}
 
-    return true;
+void read_urls_from_stream(std::vector<Url> &urls, std::istream &is, bool regex_mode) 
+{
+    std::string s;
+    while(getline(is, s)){
+        urls.emplace_back(s, regex_mode);
+    }
 }

--- a/utils.hpp
+++ b/utils.hpp
@@ -8,7 +8,11 @@
 #include <string>
 #include <vector>
 
-bool load_urls_from_file(std::vector<std::string> &urls, const std::string &filename);
+class Url;
+
+bool load_urls_from_file(std::vector<Url> &urls, const std::string &filename, bool regex_mode);
+
+void read_urls_from_stream(std::vector<Url> &urls, std::istream &is, bool regex_mode);
 
 inline char hex_digit(char c) {
     if('0' <= c and c <= '9') return (c - '0');


### PR DESCRIPTION
If the program is called like so: `urldedupe -u some_file.txt -h`, it will read the file into memory before printing the help text and exiting. While this is probably not a big issue, it is unecessary and easily fixed.
I also made it so input from `cin` and files are handled by the same function, `read_urls_from_stream`, which reads directly into a `vector<Url>`