### PR TITLE
Simplified and optimized the parsers; eliminate decoding for now

### DIFF
--- a/Url.cpp
+++ b/Url.cpp
@@ -71,6 +71,10 @@ const std::string &Url::get_url_string() const {
     return url_string;
 }
 
+bool Url::is_encoded(const std::string &u) {
+    return u.find('%') != std::string::npos;
+}
+
 std::string Url::decode(const std::string& str)
 {
     std::string ret;
@@ -96,6 +100,44 @@ std::string Url::decode(const std::string& str)
     }
     return ret;
 }
+
+std::string Url::encode(const std::string& str)
+{
+    std::string encoded_str {};
+    char bufHex[10];
+    const int len = str.length();
+
+    for (int i=0; i<len; i++)
+    {
+        auto c = str[i];
+
+        if (c == ' ')
+        {
+            encoded_str += '+';
+        }
+        else {
+            if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            {
+                encoded_str += c;
+            }
+            else {
+                sprintf(bufHex, "%X", c);
+
+                if(static_cast<int>(c) < 16)
+                {
+                    encoded_str += "%0";
+                }
+                else
+                {
+                    encoded_str += "%";
+                }
+                encoded_str += bufHex;
+            }
+        }
+    }
+    return encoded_str;
+}
+
 
 void Url::regex_parse()
 {

--- a/Url.hpp
+++ b/Url.hpp
@@ -38,7 +38,9 @@ public:
     const std::string &get_fragment() const;
     void set_fragment(const std::string &fragment);
 
+    static bool is_encoded(const std::string &u);
     static std::string decode(const std::string&);
+    static std::string encode(const std::string&);
 
     const std::string &get_url_string() const;
 

--- a/Url.hpp
+++ b/Url.hpp
@@ -38,10 +38,7 @@ public:
     const std::string &get_fragment() const;
     void set_fragment(const std::string &fragment);
 
-    static bool is_encoded(const std::string &u);
-
-    std::string decode();
-    std::string encode();
+    static std::string decode(const std::string&);
 
     const std::string &get_url_string() const;
 


### PR DESCRIPTION
Right, this is a pretty big PR.
Firstly, I deleted the decoding logic in the parsers, since decoding the URLs seems to create more bugs than it solves. `decode` is now also a static member of `Url`, since this allows us to use it to decode any part of the URL, when and if we decide to do so.
Also, I removed the `is_encoded` function, since checking if a string is encoded is not much faster than actually decoding it.
`encode` is gone, too, as it probably should have been since #2. We should never need to re-encode a URL, because we saved the original version of it. Also, encoding a substring of the URL depends on where in the URL it is located, and I feel doing this properly is going to be a lot of code for functionality we do not expect to use.
The new `parse` function is just a bit of a cleaner (and faster, thanks to `std::string_view`) version of the original one. I used ~4000 links pulled from Wikipedia (for a good mix of links containing any combination of query strings, paths and fragments) to test it against `regex_parse`, and except for some pathological examples, both methods yield the same results.