### PR TITLE
Use string_views instead of strings for Url components

### DIFF
--- a/Url.hpp
+++ b/Url.hpp
@@ -18,32 +18,25 @@ class Url
 {
   private:
     const std::string url_string;
-    std::string scheme;
-    std::string hostname;
-    std::string path;
-    std::string query_strings;
-    std::string fragment;
+    std::string_view scheme;
+    std::string_view hostname;
+    std::string_view path;
+    std::string_view query_strings;
+    std::string_view fragment;
 
   public:
     Url(const std::string &url, bool regex_mode = false);
+    Url(const Url &);
+    Url(Url &&) = default;
     ~Url() = default;
 
-    const std::string &get_scheme() const;
-    void set_scheme(const std::string &scheme);
+    std::string_view get_scheme() const;
+    std::string_view get_hostname() const;
+    std::string_view get_path() const;
+    std::string_view get_query_strings() const;
+    std::string_view get_fragment() const;
 
-    const std::string &get_hostname() const;
-    void set_hostname(const std::string &hostname);
-
-    const std::string &get_path() const;
-    void set_path(const std::string &path);
-
-    const std::string &get_query_strings() const;
-    void set_query_strings(const std::string &query_strings);
-
-    const std::string &get_fragment() const;
-    void set_fragment(const std::string &fragment);
-
-    static bool is_encoded(const std::string &u);
+    static bool is_encoded(const std::string &);
     static std::string decode(const std::string &);
     static std::string encode(const std::string &);
 

--- a/utils.hpp
+++ b/utils.hpp
@@ -27,4 +27,18 @@ inline char hex_digit(char c)
     return -1; // invalid hex digit; maybe throw instead?
 }
 
+// @brief Clone a string view referring to a string
+// @param str1 Some string
+// @param sv1 A string_view into str1
+// @param str2 A copy of str1 (or at least a string of the same length)
+// @return A string_view referring to the same substring of str2 as sv1 of str1
+inline std::string_view clone_string_view(const std::string &str1, const std::string_view &sv1, const std::string &str2)
+{
+    if (sv1.length() == 0)
+        return std::string_view(); // Empty string_view
+    auto start = sv1.data() - str1.data();
+
+    return std::string_view(str2).substr(start, sv1.length());
+}
+
 #endif // URLDEDUPE_UTILS_HPP


### PR DESCRIPTION
I made the URL components of `Url` into `string_view`s instead of full-blown `string`s, since they should only ever be sub-strings of `Url::url_string`. This should save us some allocations and copying when parsing.
This unfortunately requires some massaging when copying a `Url`, which makes the copy-constructor a bit ugly, but it should be faster.

Note: This commit seems large. This is because I already applied the formatting changes of #13 to the files. I can rebase this PR onto master if you decide you don't want to merge #13