### PR TITLE
Input using istream_iterator

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
+#include <fstream>
 #include <iostream>
 #include <string>
-#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "Url.hpp"
@@ -19,9 +20,6 @@ int main(int argc, char **argv)
         options = parse_flags(argc, argv);
     }
 
-    std::vector<Url> urls {};
-    std::string filename {};
-
     for (const Option &option: options)
     {
         if (option.flag.short_name == "-h")
@@ -37,17 +35,33 @@ int main(int argc, char **argv)
         }
 
         parse_cli_options(option, cli_options);
-
     }
 
-    if (cli_options.filename.length() > 0)
-        load_urls_from_file(urls, cli_options.filename, cli_options.regex_mode);
-    else
-        read_urls_from_stream(urls, std::cin, cli_options.regex_mode);
+    std::unique_ptr<std::ifstream> file_ptr; // Lifetime management
+    auto &input_stream = [&]() -> std::istream & {
+        if (cli_options.filename.length() > 0)
+        {
+            file_ptr = std::make_unique<std::ifstream>(cli_options.filename);
+            if (!(*file_ptr))
+            {
+                std::cout << "Unable to open file " << cli_options.filename << std::endl;
+                std::exit(-1);
+            }
+            else
+            {
+                return *file_ptr;
+            }
+        }
+        else
+        {
+            return std::cin;
+        }
+    }();
 
-    std::unordered_map<std::string, bool> deduped_url_keys;
-    for (auto &parsed_url: urls)
+    std::unordered_set<std::string> deduped_url_keys;
+    for (auto it = std::istream_iterator<std::string>(input_stream); it != std::istream_iterator<std::string>(); it++)
     {
+        auto parsed_url = Url(*it, cli_options.regex_mode);
         // Move on to the next if -qs is enabled and URL has no query strings
         if (cli_options.query_strings_only)
         {
@@ -62,13 +76,12 @@ int main(int argc, char **argv)
         }
 
         std::string url_key {parsed_url.get_url_key(cli_options.similar_mode)};
-        if (deduped_url_keys.find(url_key) != deduped_url_keys.end())
-            continue;
+        auto [_, inserted] = deduped_url_keys.insert(url_key);
 
-        deduped_url_keys.insert(std::make_pair(url_key, true));
-
-        // If it has made it to this point, it's a non-duplicate URL. Print it
-        std::cout << parsed_url.get_url_string() << std::endl;
+        if (inserted)
+        {
+            std::cout << parsed_url.get_url_string() << "\n";
+        }
     }
 
     return 0;


### PR DESCRIPTION
Using an `istream_iterator` avoids having to read an entire stream (file or `cin`) into ram before parsing the URLs, and also eliminates the `vector` full of redundant strings, since they are already stored in the set.
Referencing #15 